### PR TITLE
Implementing stream typing rules

### DIFF
--- a/compiler/verif/z3refinement.ml
+++ b/compiler/verif/z3refinement.ml
@@ -1131,6 +1131,7 @@ and vc_gen_expression ctx env ({ e_desc = desc; e_loc = loc }) typenv =
          let local_exp = vc_gen_expression ctx env l typenv in
         Printf.printf (Expr.to_string local_exp);
         Printf.printf "Body:\n";*)
+        debug(Printf.sprintf "Is recursive %b" l.l_rec);
         (List.iter (vc_gen_equation ctx env typenv) l.l_eq);
         let body_exp = vc_gen_expression ctx env e typenv in
         debug(Printf.sprintf "Body exp :%s \n" (Expr.to_string body_exp));

--- a/compiler/verif/z3refinement.ml
+++ b/compiler/verif/z3refinement.ml
@@ -619,8 +619,8 @@ and vc_gen_equation_operation ctx env typenv op e_list pat =
               let vc1 = Boolean.mk_implies ctx exp1 refinement_expr in
               let next_refinement_expr = Expr.substitute_one (refinement_expr) (base_var) (next_step_var) in
               debug(Printf.sprintf "Next refinement: %s\n" (Expr.to_string next_refinement_expr));
-              let vc2 = Boolean.mk_implies ctx (Boolean.mk_and ctx [exp1; exp3]) (next_refinement_expr) in
-              let vc = Boolean.mk_and ctx [vc1; vc2] in 
+              let vc2 = Boolean.mk_implies ctx (Boolean.mk_and ctx [refinement_expr; exp3]) (next_refinement_expr) in
+              let vc = Boolean.mk_not ctx (Boolean.mk_and ctx [vc1; vc2]) in 
               z3_proof ctx env vc refinement_expr;
             ) else (
               (* apply stream typing rule - no recursion*)

--- a/examples/my_examples/refine/fby_test.zls
+++ b/examples/my_examples/refine/fby_test.zls
@@ -1,0 +1,8 @@
+(* Some correct examples of fby streams *)
+let node main () = 
+	let rec (x:{v:int | (v < 0) || (v > 0)}) = (-1) fby (-x) in
+	let rec (y:{v:int | v >= 0}) = (0) fby (y+1) in ()
+
+(* An incorrect example *)
+(*let node main () = 
+	let rec (x:{v:int | (v >= 0)}) = (0) fby (x - 1) in ()*)

--- a/examples/my_examples/refine/subs.zls
+++ b/examples/my_examples/refine/subs.zls
@@ -1,6 +1,10 @@
-let x: {v:float | v >= 0} = 1.2
-let node main () = let (x: {v:float | v >= 0}) = 1.2 in x  
+(* let x: {v:float | v >= 0} = 1.2
+let node main () = let (x: {v:float | v >= 0}) = 1.2 in x   *)
 
 (* let node main() =
  let (x : {v : int | v >= 0}) = (0) fby (7)
  in () *)
+
+let node main () =
+let rec (x : {v : int | v >= 0}) = 0 fby (x + 1)
+in ()

--- a/examples/my_examples/refine/subs.zls
+++ b/examples/my_examples/refine/subs.zls
@@ -1,1 +1,6 @@
-let node main () = let (x: {v:float | v >= 0}) = -1.2 in x
+let x: {v:float | v >= 0} = 1.2
+let node main () = let (x: {v:float | v >= 0}) = 1.2 in x  
+
+(* let node main() =
+ let (x : {v : int | v >= 0}) = (0) fby (7)
+ in () *)

--- a/examples/my_examples/refine/unit_test.zls
+++ b/examples/my_examples/refine/unit_test.zls
@@ -135,3 +135,7 @@ let add107 x y = x+y
 
 
 (* designed to be failed cases: 3 *)
+(* 
+	EXAMPLE 11: Refinement variable typing rule
+*)
+let y6 : {v:float | v >= 0} = -1.2


### PR DESCRIPTION
- Implementation of stream typing rules required few modifications on the code

- build_return_var no longer defaults the return type variable to "float", instead it looks at the return type for the function object and uses the same base type. For void return type the sort "NULL" was added instead of return a float 42. This will likely break all the previous implementations. 

- For Evoid it now returns an uninterpreted sort "NULL" instead of float 42