### PR TITLE
Implementing typing rule for if then else

### DIFF
--- a/examples/my_examples/refine/subs.zls
+++ b/examples/my_examples/refine/subs.zls
@@ -5,6 +5,17 @@ let node main () = let (x: {v:float | v >= 0}) = 1.2 in x   *)
  let (x : {v : int | v >= 0}) = (0) fby (7)
  in () *)
 
-let node main () =
+(* let node main () =
 let rec (x : {v : int | v >= 0}) = 0 fby (x + 1)
-in ()
+in () *)
+
+let node main () =
+    let (x : {v : int | v >= 0 || v < 0}) = 5 in
+    let (x_abs : {v : int | v >= 0}) = if x < 0 then (-x) else x
+    in ()
+
+(* 
+    
+   vc:  x < 0 -> -x >= 0    and  not (x < 0)  ->  x >= 0
+
+*)


### PR DESCRIPTION
Implementation of "if e1 then e2 else e3" typing rule required few modifications:

- When creating a new type environment, include variables from higher scope
- Remove the use of `create_z3_var` to `crate_base_var_from_pattern` to account for correct base type
- Generate verification condition for typing rule