### PR TITLE
Add timestamp convenience function

### DIFF
--- a/lib/std/dune
+++ b/lib/std/dune
@@ -6,8 +6,8 @@
  (action (run zeluc -nostdlib %{deps})))
 
 (rule
- (targets char.zci complex.zci int32.zci nativeint.zci int64.zci random.zci string.zci graphics.zci basics.zci node.zci run.zci list.zci)
- (deps (:zli char.zli complex.zli int32.zli nativeint.zli int64.zli random.zli string.zli graphics.zli basics.zli node.zli run.zli list.zli) stdlib.zci)
+ (targets char.zci complex.zci int32.zci nativeint.zci int64.zci random.zci string.zci graphics.zci basics.zci node.zci run.zci list.zci timestamp.zci)
+ (deps (:zli char.zli complex.zli int32.zli nativeint.zli int64.zli random.zli string.zli graphics.zli basics.zli node.zli run.zli list.zli timestamp.zli) stdlib.zci)
  (action (run zeluc %{zli})))
 
 (rule
@@ -29,9 +29,9 @@
    ( -> defaultsolver.nosundials.ml)))
  (public_name zelus)
  (wrapped false)
- (modules ztypes zls basics zlsolve lift dump solvers illinois odexx solvers defaultsolver zlsrun run node_base node))
+ (modules ztypes zls basics zlsolve lift dump solvers illinois odexx solvers defaultsolver zlsrun run node_base node timestamp))
 
 (install
  (package zelus)
  (section share)
- (files stdlib.zci char.zci complex.zci int32.zci int64.zci nativeint.zci random.zci string.zci graphics.zci basics.zci node.zci run.zci list.zci dump.zci))
+ (files stdlib.zci char.zci complex.zci int32.zci int64.zci nativeint.zci random.zci string.zci graphics.zci basics.zci node.zci run.zci list.zci dump.zci timestamp.zci))

--- a/lib/std/timestamp.ml
+++ b/lib/std/timestamp.ml
@@ -1,0 +1,2 @@
+(* A convenience function that lets Zelus programs print the current system time *)
+let gettimeofday () = (Unix.gettimeofday ())

--- a/lib/std/timestamp.zli
+++ b/lib/std/timestamp.zli
@@ -1,0 +1,1 @@
+val gettimeofday : unit -> float


### PR DESCRIPTION
Just a single function that wraps Unix.gettimeofday since zeluc requires a zci file for any external functions being used.
Having a dedicated function for printing "wall clock" time is helpful for robot programs as it lets us match up Zelus code execution with other robot software components, and to ensure that Zelus is executing close to real time, as opposed to just using an ODE to define time (which may fall behind if the simulation slows down)